### PR TITLE
Fix root path in gitlab-proxy

### DIFF
--- a/overlay/etc/nginx/include/gitlab-proxy
+++ b/overlay/etc/nginx/include/gitlab-proxy
@@ -1,4 +1,4 @@
-root /home/gitlab/gitlab/public;
+root /home/git/gitlab/public;
 
 access_log /var/log/nginx/gitlab.access.log;
 error_log /var/log/nginx/gitlab.error.log;


### PR DESCRIPTION
The root path was pointing to the old location /home/gitlab/gitlab/public - should be /home/git/gitlab/public

This was causing errors displaying static files (ie, uploaded files)
