### PR TITLE
Update changelog for v14

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,16 @@
+turnkey-gitlab-14.0 (1) turnkey; urgency=low
+
+  * Gitlab:
+
+    - Upgraded to the latest upstream version (7.11)
+    - python-bcrypt no longer needed.
+    - Inithook now modifies password through Rails console.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <q@dae.pp.ua>  Sat, 20 Jun 2015 23:23:09 +0300
+
 turnkey-gitlab-13.0 (1) turnkey; urgency=low
 
   * Gitlab:

--- a/conf.d/10python
+++ b/conf.d/10python
@@ -1,4 +1,0 @@
-#!/bin/bash -ex
-
-pip install py-bcrypt
-

--- a/plan/main
+++ b/plan/main
@@ -22,7 +22,6 @@ ruby-dev
 
 python-dev
 python-pygments
-python-pip
 
 libicu-dev
 libssl-dev


### PR DESCRIPTION
(also remove python-bcrypt as dependency because it's no longer needed)