### PR TITLE
Fix SSL compliance in Nginx

### DIFF
--- a/overlay/etc/nginx/include/gitlab-proxy
+++ b/overlay/etc/nginx/include/gitlab-proxy
@@ -13,6 +13,7 @@ location @gitlab {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-NginX-Proxy true;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
     proxy_pass http://unix:/home/git/gitlab/tmp/sockets/gitlab.socket;
     proxy_redirect off;

--- a/overlay/etc/nginx/sites-available/gitlab
+++ b/overlay/etc/nginx/sites-available/gitlab
@@ -4,7 +4,7 @@ server {
 }
 
 server {
-    listen 0.0.0.0:443;
+    listen 0.0.0.0:443 ssl;
     include /etc/nginx/include/ssl;
     include /etc/nginx/include/gitlab-proxy;
 }


### PR DESCRIPTION
This should fix the browser errors upon accessing GitLab over HTTPS.