### PR TITLE
Integrate gitlab-workhorse on template initialisation

### DIFF
--- a/conf.d/50gitlab
+++ b/conf.d/50gitlab
@@ -82,6 +82,14 @@ exec_git "cat >>$GIT_HOME/gitlab/app/views/layouts/application.html.haml<<EOF
 <div id='turnkey-credit' style='font-size:10px;text-align:center;padding-top:20px'><a href='https://www.turnkeylinux.org/gitlab'>GitLab Appliance</a> - Powered by <a href='https://www.turnkeylinux.org'>TurnKey Linux</a></div>
 EOF"
 
+
+
+# fetch and compile gitlab-workhorse
+URL_WORKHORSE = "https://gitlab.com/gitlab-org/gitlab-workhorse"
+exec_git "git clone $URL_WORKHORSE $GIT_HOME/gitlab-workhorse"
+exec_git "make -C $GIT_HOME/gitlab-workhorse"
+
+
 # set permissions
 chown -R $GIT_USER $GIT_HOME/gitlab/log
 chown -R $GIT_USER $GIT_HOME/gitlab/tmp

--- a/overlay/etc/nginx/include/gitlab-proxy
+++ b/overlay/etc/nginx/include/gitlab-proxy
@@ -15,7 +15,7 @@ location @gitlab {
     proxy_set_header X-NginX-Proxy true;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    proxy_pass http://unix:/home/git/gitlab/tmp/sockets/gitlab.socket;
+    proxy_pass http://gitlab;
     proxy_redirect off;
     proxy_buffering off;
 }

--- a/overlay/etc/nginx/include/gitlab-proxy
+++ b/overlay/etc/nginx/include/gitlab-proxy
@@ -20,3 +20,17 @@ location @gitlab {
     proxy_buffering off;
 }
 
+location ~ [-\/\w\.]+\.git\/ {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_pass http://gitlab-workhorse;
+    proxy_redirect off;
+    proxy_buffering off;
+    
+    proxy_connect_timeout 300;
+    proxy_read_timeout 300;
+}

--- a/overlay/etc/nginx/sites-available/gitlab
+++ b/overlay/etc/nginx/sites-available/gitlab
@@ -2,6 +2,10 @@ upstream gitlab {
     server unix:/home/git/gitlab/tmp/sockets/gitlab.socket fail_timeout=0;
 }
 
+upstream gitlab-workhorse {
+    server unix:/home/git/gitlab/tmp/sockets/gitlab-workhorse.socket fail_timeout=0;
+}
+
 server {
     listen 0.0.0.0:80;
     include /etc/nginx/include/gitlab-proxy;

--- a/overlay/etc/nginx/sites-available/gitlab
+++ b/overlay/etc/nginx/sites-available/gitlab
@@ -1,3 +1,7 @@
+upstream gitlab {
+    server unix:/home/git/gitlab/tmp/sockets/gitlab.socket fail_timeout=0;
+}
+
 server {
     listen 0.0.0.0:80;
     include /etc/nginx/include/gitlab-proxy;

--- a/plan/main
+++ b/plan/main
@@ -41,3 +41,5 @@ sudo
 nodejs
 
 python-bcrypt
+
+golang


### PR DESCRIPTION
Solve https://github.com/turnkeylinux/tracker/issues/686 (can't open issue on this repo)

Fetch and make gitlab-workhorse to complete all the Gitlab dependencies.

_gitlab-workhorse_ is expected by the Gitlab startup process (see /etc/init.d/gitlab), additionally HTTP requests are optimized and avoid some errors related to HTTP operations through git client (i.e https://gitlab.com/gitlab-org/gitlab-ce/issues/2669#note_2176671)

**This PR**
0) Add GO as a dependency (make gitlab-workhorse)
1) Integrate gitlab-workhorse on the Gitlab installation process
2) Change consume socket directly on proxy_pass@nginx to upstream
3) Create a new location matching *.git requests that points to the workhorse upstream

Among other things, issues like "empty repo" at "git clone http://XXXX" will be solved.