### PR TITLE
Clean up inithooks

### DIFF
--- a/overlay/usr/lib/inithooks/bin/gitlab.py
+++ b/overlay/usr/lib/inithooks/bin/gitlab.py
@@ -32,8 +32,10 @@ def usage(s=None):
 
 def main():
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], "h",
-                                       ['help', 'pass=', 'email=', 'domain='])
+        opts, args = getopt.gnu_getopt(
+                sys.argv[1:], "h",
+                ['help', 'pass=', 'email=', 'domain=', 'schema=']
+                )
     except getopt.GetoptError as e:
         usage(e)
 

--- a/overlay/usr/lib/inithooks/bin/gitlab.py
+++ b/overlay/usr/lib/inithooks/bin/gitlab.py
@@ -108,8 +108,12 @@ def main():
     p2 = Popen(["gitlab-rake", "gitlab:password:reset[root]"],
                stdin=p1.stdout, stdout=PIPE)
     p1.stdout.close()
+    if p2.returncode == 0:
+        stream = sys.stdout
+    else:
+        stream = sys.stderr
     output = p2.communicate()[0]
-    print(output)
+    print(output.decode(), file=stream)
     sys.exit(p2.returncode)
 
 

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-gitlab-secrets
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-gitlab-secrets
@@ -6,12 +6,6 @@
 # already removed during initial build, but just in case they're being re-run.
 mv /etc/gitlab/gitlab-secrets.json /etc/gitlab/gitlab-secrets.json.bak || true
 
-if ! $(systemctl is-active --quiet gitlab-runsvdir.service); then
+if ! systemctl is-active --quiet gitlab-runsvdir.service; then
     systemctl start gitlab-runsvdir.service
 fi
-
-# As of v15.2 the TurnKey GitLab appliance installs the Omnibus package, so
-# there is nothing more to do here.
-#
-# That is because with no secrets file, when 'gitlab-ctl reconfigure' is called
-# (by 'bin/gitlab.py' inithook) the secrets are regenerated.

--- a/overlay/usr/lib/inithooks/firstboot.d/40gitlab
+++ b/overlay/usr/lib/inithooks/firstboot.d/40gitlab
@@ -3,18 +3,18 @@
 
 . /etc/default/inithooks
 
-exit_status=0
+fatal() { echo "$(basename "$0"): FATAL: $*" >&2; exit 1; }
 
 # if GitLab isn't already running, start it
-if ! $(systemctl is-active --quiet gitlab-runsvdir.service); then
+if ! systemctl is-active --quiet gitlab-runsvdir.service; then
     systemctl start gitlab-runsvdir.service
 fi
 
-[ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
-$INITHOOKS_PATH/bin/gitlab.py --pass="$APP_PASS" --email="$APP_EMAIL" --domain="$APP_DOMAIN" \
-    || exit_status=1 # ensure that temp service is disabled even if gitlab inithook fails
+if [[ -f "$INITHOOKS_CONF" ]]; then
+    source "$INITHOOKS_CONF"
+else
+    echo "$(basename "$0"): Warning: $INITHOOKS_CONF not found or is not a file (expected if not preseeded" >&2
+fi
 
-# moved token reset to $INITHOOKS_PATH/bin/gitlab.py - at the same time as
-# setting password - should fix #1315/#1342 for good!
-
-exit $exit_status
+"$INITHOOKS_PATH/bin/gitlab.py" --pass="$APP_PASS" --email="$APP_EMAIL" --domain="$APP_DOMAIN" \
+    || fatal "$INITHOOKS_PATH/bin/gitlab.py failed"


### PR DESCRIPTION
`firstboot.d` bash inithook updates:
 - apply shellcheck fixes
 - remove redundant comments & code
 - improve readability
 - other minor tweaks

`bin` python inithook update:
- add missing `schema` to cli options (included in help, but not in `getopt` options)
- GL password setting output as string (not binary string)
- GL password setting output to relevant stream - i.e. error to `stderr`